### PR TITLE
reset mSmsReceiver to null on stopOTPListener to fix subscribe workin…

### DIFF
--- a/src/android/OTPAutoVerification.java
+++ b/src/android/OTPAutoVerification.java
@@ -100,6 +100,7 @@ public class OTPAutoVerification extends CordovaPlugin {
     private void stopOTPListener(){
         if(this.mSmsReceiver !=null){
             cordova.getActivity().unregisterReceiver(mSmsReceiver);
+            this.mSmsReceiver = null;
             Log.d("SANDY Debugger", "stopOTPListener");
         }
     }


### PR DESCRIPTION
Currently calling startOTPListener again after calling stopOTPListener, plugin is not working.

We should reset mSmsReceiver to null on stopOTPListener to get subscribe working on calling startOTPListener again.